### PR TITLE
Add 'number' directive in workspace command

### DIFF
--- a/i3/i3.go
+++ b/i3/i3.go
@@ -32,7 +32,7 @@ func SetCurrentWorkspace(workspaceNum int64) error {
 func UpdateWorkspaces(display config.Display) error {
 	for _, workspace := range display.Workspaces {
 
-		command := fmt.Sprintf("workspace %d; move workspace to %s", workspace, display.Name)
+		command := fmt.Sprintf("workspace number %d; move workspace to %s", workspace, display.Name)
 		_, err := i3.RunCommand(command)
 
 		if err != nil {


### PR DESCRIPTION
Hi,
This PR simply adds the 'number' keyword when switching between workspaces, to add compatibility with dynamically-named workspaces.
See https://i3wm.org/docs/userguide.html#_changing_named_workspaces_moving_to_workspaces