### PR TITLE
Correct syntax to move a workspace to an output

### DIFF
--- a/i3/i3.go
+++ b/i3/i3.go
@@ -32,7 +32,7 @@ func SetCurrentWorkspace(workspaceNum int64) error {
 func UpdateWorkspaces(display config.Display) error {
 	for _, workspace := range display.Workspaces {
 
-		command := fmt.Sprintf("workspace number %d; move workspace to %s", workspace, display.Name)
+		command := fmt.Sprintf("workspace number %d; move workspace to output %s", workspace, display.Name)
 		_, err := i3.RunCommand(command)
 
 		if err != nil {


### PR DESCRIPTION
according to [the docs](https://i3wm.org/docs/userguide.html#move_to_outputs), the correct syntax for moving a workspace to an output is 

```
move workspace to output left|right|down|up|current|primary|<output>
```