### PR TITLE
Add support for turning off monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ displays:
     randr_extra_options: "--left-of HDMI1"
 ```
 
+If you'd like to have your laptop monitor turned off when an external one is connected, here's another example ('eDP-1' being the laptop screen):
+```yaml
+displays:
+  - name: eDP-1
+    workspaces: [1,2,3,4,5,6,7,8,9,0]
+    turn_off_when: ["DP-1"]
+  - name: DP-1
+    workspaces: [1,2,3,4,5,6,7,8,9,0]
+```

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,8 @@ import (
 
 type Display struct {
 	Name              string
-	RandrExtraOptions string `yaml:"randr_extra_options"`
+	RandrExtraOptions string   `yaml:"randr_extra_options"`
+	TurnOffWhen       []string `yaml:"turn_off_when"`
 	Workspaces        []int
 }
 

--- a/display/randr.go
+++ b/display/randr.go
@@ -46,7 +46,7 @@ func Refresh() {
 
 	args := []string{}
 	for _, display := range config.Config.Displays {
-		active := currentOutputConfiguration[display.Name]
+		active := isDisplayActive(display, currentOutputConfiguration)
 		args = append(args, getDisplayOptions(display, active)...)
 	}
 
@@ -59,7 +59,7 @@ func Refresh() {
 	}
 
 	for _, display := range config.Config.Displays {
-		if currentOutputConfiguration[display.Name] {
+		if isDisplayActive(display, currentOutputConfiguration) {
 			refreshDisplay(display)
 		}
 	}
@@ -94,6 +94,18 @@ func ListenEvents() {
 			Refresh()
 		}
 	}
+}
+
+func isDisplayActive(display config.Display, currentOutputConfiguration map[string]bool) bool {
+	if !currentOutputConfiguration[display.Name] {
+		return false
+	}
+	for _, d := range display.TurnOffWhen {
+		if currentOutputConfiguration[d] {
+			return false
+		}
+	}
+	return true
 }
 
 func getDisplayOptions(display config.Display, active bool) []string {


### PR DESCRIPTION
In my workflow, I'd like to be able to turn off a display when another one is present. For example, I don't need a laptop monitor when an external one is connected.

This PR introduces `turn_off_when` option which does exactly that. See example in README.md file. By the way, if you have better ideas for the name, I'm open for them.

In addition to that, I'm adding retries to the `xrandr` call because in my workflow they are necessary sometimes during suspend/wake up routines.