### PR TITLE
Update only workspaces on wrong output

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 type Display struct {
 	Name              string
 	RandrExtraOptions string `yaml:"randr_extra_options"`
-	Workspaces        []int
+	Workspaces        []int64
 }
 
 var Config = struct {

--- a/i3/i3.go
+++ b/i3/i3.go
@@ -30,13 +30,21 @@ func SetCurrentWorkspace(workspaceNum int64) error {
 }
 
 func UpdateWorkspaces(display config.Display) error {
+	ws, err := i3.GetWorkspaces()
+	if err != nil {
+		return err
+	}
+
 	for _, workspace := range display.Workspaces {
+		for _, w := range ws {
+			if w.Num == workspace && w.Output != display.Name {
+				command := fmt.Sprintf("workspace number %d; move workspace to output %s", workspace, display.Name)
+				_, err := i3.RunCommand(command)
 
-		command := fmt.Sprintf("workspace number %d; move workspace to output %s", workspace, display.Name)
-		_, err := i3.RunCommand(command)
-
-		if err != nil {
-			return err
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes "No output matched" error with i3wm 4.20
(caused by bug https://github.com/i3/i3/issues/4691)