### PR TITLE
Refactor: Replace Deprecated Function and Migrate to Maintained XGB Fork

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -22,7 +21,7 @@ var Config = struct {
 
 func init() {
 	configFile := getConfirFilePath()
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 
 	if err != nil {
 		log.Fatalf("error reading configuration file: %s", err)

--- a/display/randr.go
+++ b/display/randr.go
@@ -12,9 +12,6 @@ import (
 	"github.com/jezek/xgb/xproto"
 	"github.com/lpicanco/i3-autodisplay/config"
 	"github.com/lpicanco/i3-autodisplay/i3"
-	// "github.com/BurntSushi/xgb/randr"
-	// "github.com/BurntSushi/xgb/xproto"
-	// "github.com/lpicanco/i3-autodisplay/config"
 )
 
 var (

--- a/display/randr.go
+++ b/display/randr.go
@@ -6,12 +6,15 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/lpicanco/i3-autodisplay/i3"
+	"github.com/jezek/xgb"
 
-	"github.com/BurntSushi/xgb"
-	"github.com/BurntSushi/xgb/randr"
-	"github.com/BurntSushi/xgb/xproto"
+	"github.com/jezek/xgb/randr"
+	"github.com/jezek/xgb/xproto"
 	"github.com/lpicanco/i3-autodisplay/config"
+	"github.com/lpicanco/i3-autodisplay/i3"
+	// "github.com/BurntSushi/xgb/randr"
+	// "github.com/BurntSushi/xgb/xproto"
+	// "github.com/lpicanco/i3-autodisplay/config"
 )
 
 var (
@@ -21,7 +24,7 @@ var (
 
 func init() {
 	var err error
-	
+
 	xgbConn, err = xgb.NewConn()
 	if err != nil {
 		log.Fatalf("error initializing xgb: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843
+	github.com/jezek/xgb v1.1.1 // indirect
 	go.i3wm.org/i3/v4 v4.18.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e h1:4ZrkT/RzpnRO
 github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e/go.mod h1:uw9h2sd4WWHOPdJ13MQpwK5qYWKYDumDqxWWIknEQ+k=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
+github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 go.i3wm.org/i3/v4 v4.18.0 h1:yV9SCpYeyTqEuele2bw7rLmEfrGCRlid9enTqLjPuG0=
 go.i3wm.org/i3/v4 v4.18.0/go.mod h1:FN6trxp2TXmfzQVa6JSKq5IJx/XUJsnPFKAz15cBWtw=
 golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc h1:ZMCWScCvS2fUVFw8LOpxyUUW5qiviqr4Dg5NdjLeiLU=


### PR DESCRIPTION
### Summary This PR includes the following changes:

- Replaced deprecated ioutil.ReadFile with os.ReadFile to maintain code compatibility and future-proofing.

- Migrated from the unmaintained github.com/BurntSushi/xgb to the recommended fork https://github.com/jezek/xgb to ensure continued support and maintenance.

These updates enhance code reliability and align with best practices.